### PR TITLE
Invalid upstream response (403), URL error

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -561,7 +561,7 @@ receive the very special Contributor T-shirt! Go ahead and fill out the
 Proudly wear your T-shirt and show it to us by tagging
 [@thekonginc](https://twitter.com/thekonginc) on Twitter!
 
-![Kong Contributor T-shirt](https://konghq.com/wp-content/uploads/2018/04/100-contributor-t-shirt-1024x768.jpg)
+![Kong Contributor T-shirt](https://github.com/Nikhil8557/kong/assets/71388692/df754f5f-5286-489a-9051-4f5f07e7cfd4)
 
 [Back to TOC](#table-of-contents)
 
@@ -970,4 +970,3 @@ ngx.log(ngx.DEBUG, "if `my_var` is nil, this code is fine: ", my_var)
 [Back to code style TOC](#table-of-contents---code-style)
 
 [Back to TOC](#table-of-contents)
-


### PR DESCRIPTION
<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing

Refer to the Kong Gateway Community Pledge to understand how we work
with the open source community:
https://github.com/Kong/kong/blob/master/COMMUNITY_PLEDGE.md
-->

### Summary

_**Url which is supposed to show the Image of "T-Shirt" is showing "Invalid upstream response (403)". I changed the url to local upload url of Github user content domain. Kong can change it accordingly.....**_
### Reference 
![SmartSelect_20240228_012642_Chrome](https://github.com/Nikhil8557/kong/assets/71388692/93d92b7f-cb4d-4d9f-92f8-6e4d73aef50e)

### Checklist

- [ ] The Pull Request has tests
- [ ] A changelog file has been created under `changelog/unreleased/kong` or `skip-changelog` label added on PR if changelog is unnecessary. [README.md](https://github.com/Kong/gateway-changelog/README.md)
- [ ] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE

### Issue reference

<!--- If it fixes an open issue, please link to the issue here

. -->
Fix #_[issue number]_
